### PR TITLE
Fixed  GitHub links from `brendt` to `rfc-vote`

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -3,7 +3,7 @@ require __DIR__.'/vendor/autoload.php';
 
 $server = "stitcher.io";
 $userAndServer = 'forge@'. $server;
-$repository = "brendt/rfc-vote.git";
+$repository = "rfc-vote/rfc-vote.git";
 $baseDir = "/home/forge/rfc.stitcher.io";
 $releasesDir = "{$baseDir}/releases";
 $currentDir = "{$baseDir}/current";

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the specific documentation on Sail page for [Laravel Dusk](https://laravel.com/d
     # For Apple Silicon (m1, m2) replace the value with seleniarm/standalone-chromium, see https://laravel.com/docs/10.x/sail#laravel-dusk for more details
     SELENIUM_IMAGE=selenium/standalone-chrome
     ```
-   This enables the choice of selenium image as per your system's architecture. For more context on this, please refer to [this PR discussion](https://github.com/brendt/rfc-vote/pull/234#issuecomment-1700920222)
+   This enables the choice of selenium image as per your system's architecture. For more context on this, please refer to [this PR discussion](https://github.com/rfc-vote/rfc-vote/pull/234#issuecomment-1700920222)
 
 2. **Database Configuration:**
 

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -41,8 +41,8 @@
 
 <x-about.section heading="Who's involved?">
     <p>Many people throughout the PHP community have already
-        <x-about.link href="https://github.com/brendt/rfc-vote/graphs/contributors">contributed to this project</x-about.link>
-        — and <x-about.link href="https://github.com/brendt/rfc-vote">you can too</x-about.link>!</p>
+        <x-about.link href="https://github.com/rfc-vote/rfc-vote/graphs/contributors">contributed to this project</x-about.link>
+        — and <x-about.link href="https://github.com/rfc-vote/rfc-vote">you can too</x-about.link>!</p>
 
     <p>The initial idea came from <x-about.link href="https://twitter.com/pronskiy">Roman Pronskiy</x-about.link>,
         who helps administer the <x-about.link href="https://thephp.foundation/">PHP Foundation</x-about.link>,
@@ -70,7 +70,7 @@
 <x-about.section heading="Interesting links">
     <ul {{dusk('interesting-links-container')}}>
         <li>
-            <x-about.link href="https://github.com/brendt/rfc-vote">
+            <x-about.link href="https://github.com/rfc-vote/rfc-vote">
                 <x-icons.link class="w-4 h-4 inline-block mr-1" />
                 The RFC Vote repository
             </x-about.link>

--- a/resources/views/components/footer/footer.blade.php
+++ b/resources/views/components/footer/footer.blade.php
@@ -7,7 +7,7 @@
             RSS Feed
         </x-footer.link>
 
-        <x-footer.link href="https://github.com/brendt/rfc-vote" icon="icons.github">
+        <x-footer.link href="https://github.com/rfc-vote/rfc-vote" icon="icons.github">
             Contribute
         </x-footer.link>
 
@@ -15,7 +15,7 @@
             Watch on YouTube
         </x-footer.link>
 
-        <x-footer.link href="https://raw.githubusercontent.com/brendt/rfc-vote/main/LICENSE.md" icon="icons.document">
+        <x-footer.link href="https://raw.githubusercontent.com/rfc-vote/rfc-vote/main/LICENSE.md" icon="icons.document">
             Our License
         </x-footer.link>
     </div>
@@ -23,7 +23,7 @@
     <div class="text-center opacity-70 mt-7">
         <small>
             &copy; {{ date('Y') }} {{ config('app.name') }}. This project is open source.
-            <a href="https://github.com/brendt/rfc-vote" class="underline" target="_blank">Contribute</a>
+            <a href="https://github.com/rfc-vote/rfc-vote" class="underline" target="_blank">Contribute</a>
             and collaborate with us!</p>
         </small>
     </div>


### PR DESCRIPTION
Because we moved the repository to an organization and the URL has changed